### PR TITLE
Fixed Navbar Login/Account button on Mobile.

### DIFF
--- a/src/client/NavBar.tsx
+++ b/src/client/NavBar.tsx
@@ -78,6 +78,7 @@ export default function NavBar() {
               >
                 GPT
               </Disclosure.Button>
+              {user ? (
               <Disclosure.Button
                 as='a'
                 href='/account'
@@ -85,6 +86,15 @@ export default function NavBar() {
               >
                 Account
               </Disclosure.Button>
+              )   :   (
+                <Disclosure.Button
+                as='a'
+                href='/login'
+                className='block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800'
+              >
+                Account
+              </Disclosure.Button>
+              )}
             </div>
           </Disclosure.Panel>
         </>


### PR DESCRIPTION
While trying to set-up the template for the first time I noticed that my Login button was not working on mobile and it was simply redirecting me to the main page (or to be more exact - to the /account page but I was not logged in).

The purpose of this PR is to fix the issue by adding an user check that switches between /account and /login depending on Auth state, like on Desktop.

Old behaviour:
- User can't login on mobile (unless explicitly going to /login) because the Account button is not directing to the login page first.

New behaviour:

- For logged in users, the Account button will direct them to their account page.
- For logged out users, the Account button will direct them to the login page.



Please review the changes and let me know if any further modifications are required.

```
+      {user ? (
       <Disclosure.Button
         as='a'
         href='/account'
         className='block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800'
       >
         Account
       </Disclosure.Button>
+      )   :   (
+        <Disclosure.Button
+        as='a'
+        href='/login'
+        className='block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800'
+      >
+        Account
+      </Disclosure.Button>
+      )}

```