### PR TITLE
Updated .env file (minor spelling mistake)

### DIFF
--- a/env.server.example
+++ b/env.server.example
@@ -10,5 +10,5 @@ GOOGLE_CLIENT_SECRET=
 OPENAI_API_KEY=
 
 SENDGRID_API_KEY=
-# if not excplicitly set to true, emails be logged to console but not actually sent
+# if not explicitly set to true, emails be logged to console but not actually sent
 SEND_EMAILS_IN_DEVELOPMENT=true


### PR DESCRIPTION
"excplicitly": spelt incorrectly: explicitly (correction)

Super minor but just happened to notice it since my IDE was unnecessarily flagging errors in the file. 